### PR TITLE
High-pressure Pascal Disambiguation

### DIFF
--- a/15-pascal/README.md
+++ b/15-pascal/README.md
@@ -1,4 +1,4 @@
-# [Day 15](https://adventofcode.com/2020/day/15) solution in [Pascal](https://en.wikipedia.org/wiki/Pascal_(unit))
+# [Day 15](https://adventofcode.com/2020/day/15) solution in [Pascal](https://en.wikipedia.org/wiki/Pascal_(programming_language))
 
 ## Tested on
 


### PR DESCRIPTION
Updated link to point to Pascal the programming language, not the SI derived unit.

Pog.